### PR TITLE
Do not post full toot if is marked as sensitive

### DIFF
--- a/daemons/check_for_toots.rb
+++ b/daemons/check_for_toots.rb
@@ -127,10 +127,18 @@ class CheckForToots
   def self.process_normal_toot(toot, user)
     Rails.logger.debug{ "Processing toot: #{toot.text_content}" }
     if should_post(toot, user)
-      tweet_content = TootTransformer.transform(toot.text_content, toot.url)
+      tweet_content = TootTransformer.transform(toot_content_to_post(toot), toot.url)
       tweet(tweet_content, user)
     else
       Rails.logger.debug('Ignoring normal toot because of visibility configuration')
+    end
+  end
+
+  def self.toot_content_to_post(toot)
+    if toot.sensitive?
+      "CW: #{toot.spoiler_text} … #{toot.url}"
+    else
+      toot.text_content
     end
   end
 

--- a/lib/mastodon_ext.rb
+++ b/lib/mastodon_ext.rb
@@ -29,6 +29,12 @@ module Mastodon
     def is_public?
       !(is_private? || is_unlisted? || is_direct?)
     end
+    def sensitive?
+      self.attributes['sensitive']
+    end
+    def spoiler_text
+      self.attributes['spoiler_text']
+    end
     def self.scrubber
       @@scrubber ||= Rails::Html::PermitScrubber.new
       @@scrubber.tags = ['br', 'p']


### PR DESCRIPTION
When marked as sensitive, the toot should be posted as CW: reason, plus
the link. This way the content is handled by the Mastodon instance, instead
of appearing on twitter.

Fixes #1