### PR TITLE
Add option to fix cross mentions

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,6 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:posting_from_mastodon, :masto_should_post_private, :masto_should_post_unlisted, :boost_options, :masto_reply_options, :masto_mention_options)
+    params.require(:user).permit(:posting_from_mastodon, :masto_should_post_private, :masto_should_post_unlisted, :boost_options, :masto_reply_options, :masto_mention_options, :masto_fix_cross_mention)
   end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -29,6 +29,16 @@
   </label>
 <% end %>
 </div>
+<p>Fix cross mentions?<br />
+<small>When this option is on, if you post a toot that contains '@user@twitter.com', this will be replaced by '@user' when posted in twitter.</small></p>
+<div class="btn-group" data-toggle="buttons">
+<% [true, false].each do |option| %>
+  <label class="btn btn-primary<% if current_user.masto_fix_cross_mention == option %> active<% end %>">
+    <%= f.radio_button :masto_fix_cross_mention, option %>
+    <%= t "masto_sync_status_#{option}".to_sym %>
+  </label>
+<% end %>
+</div>
 <p>Boost options:<br />
 <% User.boost_options.keys.each do |boost_option| %>
 <div class="radio">

--- a/daemons/check_for_toots.rb
+++ b/daemons/check_for_toots.rb
@@ -174,4 +174,18 @@ Signal.trap("INT") {
 
 Rails.logger.debug { "Starting" }
 
+twitter_client = Twitter::REST::Client.new do |config|
+  config.consumer_key = ENV['TWITTER_CLIENT_ID']
+  config.consumer_secret = ENV['TWITTER_CLIENT_SECRET']
+end
+
+begin
+  TootTransformer::twitter_short_url_length = twitter_client.configuration.short_url_length
+  TootTransformer::twitter_short_url_length_https = twitter_client.configuration.short_url_length_https
+rescue Twitter::Error::Forbidden => ex
+  Rails.logger.error { "Missing Twitter credentials" }
+  exit
+end
+
+
 CheckForToots::available_since_last_check

--- a/daemons/check_for_toots.rb
+++ b/daemons/check_for_toots.rb
@@ -128,7 +128,7 @@ class CheckForToots
   def self.process_normal_toot(toot, user)
     Rails.logger.debug{ "Processing toot: #{toot.text_content}" }
     if should_post(toot, user)
-      tweet_content = TootTransformer.transform(toot_content_to_post(toot), toot.url)
+      tweet_content = TootTransformer.transform(toot_content_to_post(toot), toot.url, user.masto_fix_cross_mention)
       tweet(tweet_content, user)
     else
       Rails.logger.debug('Ignoring normal toot because of visibility configuration')

--- a/db/migrate/20170817073406_add_masto_fix_cross_mention_to_users.rb
+++ b/db/migrate/20170817073406_add_masto_fix_cross_mention_to_users.rb
@@ -1,0 +1,5 @@
+class AddMastoFixCrossMentionToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :masto_fix_cross_mention, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -162,7 +162,8 @@ CREATE TABLE users (
     masto_should_post_private boolean DEFAULT false,
     masto_should_post_unlisted boolean DEFAULT false,
     posting_from_mastodon boolean DEFAULT false,
-    posting_from_twitter boolean DEFAULT false
+    posting_from_twitter boolean DEFAULT false,
+    masto_fix_cross_mention boolean DEFAULT false
 );
 
 
@@ -277,6 +278,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170810103418'),
 ('20170810105204'),
 ('20170810105214'),
-('20170812195419');
+('20170812195419'),
+('20170817073406');
 
 

--- a/lib/toot_transformer.rb
+++ b/lib/toot_transformer.rb
@@ -1,8 +1,10 @@
 class TootTransformer
   HTTP_REGEX = /^(?:http:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:\/?#\[\]@!\$&'\(\)\*\+,;=.]+$/
   HTTPS_REGEX = /^(?:https:\/\/)[\w.-]+(?:\.[\w.-]+)+[\w\-._~:\/?#\[\]@!\$&'\(\)\*\+,;=.]+$/
+  TWITTER_MENTION_REGEX = /@([^@]+)@twitter.com/
   TWITTER_MAX_LENGTH = 140
-  def self.transform(text, toot_url)
+  def self.transform(text, toot_url, fix_cross_mention)
+    text.gsub!(TWITTER_MENTION_REGEX, '@\1') if fix_cross_mention
     http_count, http_length = count_regex(text, HTTP_REGEX)
     https_count, https_length = count_regex(text, HTTPS_REGEX)
     final_length = (text.length - http_length - https_length) + http_count*twitter_short_url_length + https_count*twitter_short_url_length_https


### PR DESCRIPTION
This PR adds the option to fix cross mentions from masto to twitter. Add checks for bad auth on twitter side and destroy authorization on that case, get short urls lengths from twitter api and exit when missing credentials.