### PR TITLE
Disable mentions on twitter temporarily

### DIFF
--- a/lib/toot_transformer.rb
+++ b/lib/toot_transformer.rb
@@ -10,7 +10,7 @@ class TootTransformer
   end
 
   def self.transform(text, toot_url, mastodon_domain, fix_cross_mention)
-    text.gsub!(TWITTER_MENTION_REGEX, '@\1') if fix_cross_mention
+    text.gsub!(TWITTER_MENTION_REGEX, '\1') if fix_cross_mention
     text.gsub!(media_regex(mastodon_domain), '')
     transform_rec(text, toot_url, TWITTER_MAX_LENGTH)
   end

--- a/test/lib/toot_transformer_test.rb
+++ b/test/lib/toot_transformer_test.rb
@@ -49,8 +49,15 @@ class TootTransformerTest < ActiveSupport::TestCase
   end
 
   test 'Transform text with twitter mention in it' do
+    skip('Twitter mention is temporarily disabled')
     text = 'Hey, @renatolond@twitter.com, how is it going?'
     expected_text = 'Hey, @renatolond, how is it going?'
+
+    assert_equal expected_text, TootTransformer::transform(text, 'https://mastodon.xyz/@renatolond/1111111', 'https://mastodon.xyz', true)
+  end
+  test 'Transform text with twitter mention in it and omit the @' do
+    text = 'Hey, @renatolond@twitter.com, how is it going?'
+    expected_text = 'Hey, renatolond, how is it going?'
 
     assert_equal expected_text, TootTransformer::transform(text, 'https://mastodon.xyz/@renatolond/1111111', 'https://mastodon.xyz', true)
   end


### PR DESCRIPTION
The app was blocked from writing because of mention spam, until the
matter can be investigated further, we're disabling the mentions to
avoid problems.