### PR TITLE
Connect domain to mastodon client

### DIFF
--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -1,5 +1,24 @@
 class Authorization < ApplicationRecord
   belongs_to :user, inverse_of: :authorizations, required: true
+  belongs_to :mastodon_client, required: false
 
   default_scope { order('id asc') }
+
+  def fetch_profile_data
+    if self.provider == 'twitter'
+      user.save_last_tweet_id
+    elsif self.provider == 'mastodon'
+      self.mastodon_client = MastodonClient.find_by_domain(mastodon_domain) if self.new_record?
+      if self.mastodon_client.nil?
+        Rails.logger.error { "Could not find MastodonClient for #{uid}" }
+      end
+      user.save_last_toot_id
+    end
+  end
+
+  private
+
+  def mastodon_domain
+    uid.split('@').last
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,7 +60,7 @@ class User < ApplicationRecord
   end
 
   def mastodon_domain
-    @mastodon_domain ||= "https://#{mastodon.uid.split('@').last}"
+    @mastodon_domain ||= "https://#{mastodon.mastodon_client.domain}"
   end
 
   def mastodon_client
@@ -88,13 +88,9 @@ class User < ApplicationRecord
     authorization.token  = auth.credentials.token
     authorization.secret = auth.credentials.secret
 
-    authorization.save
+    authorization.fetch_profile_data if authorization.token_changed?
 
-    if auth.provider == 'twitter' and user.last_tweet.nil?
-      authorization.user.save_last_tweet_id
-    elsif auth.provider == 'mastodon' and user.last_toot.nil?
-      authorization.user.save_last_toot_id
-    end
+    authorization.save
 
     authorization.user
   end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -257,7 +257,7 @@ Devise.setup do |config|
 
     return [client.client_id, client.client_secret] unless client.new_record?
 
-    new_client = Mastodon::REST::Client.new(base_url: "https://#{domain}").create_app('Mastodon Twitter Crossposter', callback_url, 'read write')
+    new_client = Mastodon::REST::Client.new(base_url: "https://#{domain}").create_app('Mastodon Twitter Crossposter', callback_url, 'read write', 'https://crossposter.masto.donte.com.br')
 
     client.client_id = new_client.client_id
     client.client_secret = new_client.client_secret

--- a/db/migrate/20171025125328_add_mastodon_client_to_authorization.rb
+++ b/db/migrate/20171025125328_add_mastodon_client_to_authorization.rb
@@ -1,0 +1,5 @@
+class AddMastodonClientToAuthorization < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :authorizations, :mastodon_client, foreign_key: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -79,7 +79,8 @@ CREATE TABLE authorizations (
     token character varying,
     secret character varying,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    mastodon_client_id bigint
 );
 
 
@@ -248,6 +249,13 @@ ALTER TABLE ONLY users
 
 
 --
+-- Name: index_authorizations_on_mastodon_client_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_authorizations_on_mastodon_client_id ON authorizations USING btree (mastodon_client_id);
+
+
+--
 -- Name: index_authorizations_on_provider_and_uid; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -259,6 +267,14 @@ CREATE UNIQUE INDEX index_authorizations_on_provider_and_uid ON authorizations U
 --
 
 CREATE UNIQUE INDEX index_mastodon_clients_on_domain ON mastodon_clients USING btree (domain);
+
+
+--
+-- Name: authorizations fk_rails_7cfd93d6c7; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY authorizations
+    ADD CONSTRAINT fk_rails_7cfd93d6c7 FOREIGN KEY (mastodon_client_id) REFERENCES mastodon_clients(id);
 
 
 --
@@ -280,6 +296,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170810105214'),
 ('20170812195419'),
 ('20170817073406'),
-('20171012093059');
+('20171012093059'),
+('20171025125328');
 
 

--- a/test/factories/authorization.rb
+++ b/test/factories/authorization.rb
@@ -1,16 +1,25 @@
 FactoryGirl.define do
-  factory :authorization, aliases: [:authorization_mastodon] do
-    provider :mastodon
-    uid Faker::Internet.email
-    user
-    token 'a-beautiful-token-here'
-  end
-
-  factory :authorization_twitter, parent: :authorization do
+  factory :authorization, aliases: [:authorization_twitter] do
     provider :twitter
     uid 123456
     user
-    token 'another-beautiful-token-here'
+    token 'a-beautiful-token-here'
     secret 'another-beautiful-secret-here'
+  end
+
+  factory :authorization_mastodon, parent: :authorization do
+    transient do
+      masto_domain nil
+    end
+    provider :mastodon
+    uid Faker::Internet.email
+    user
+    token 'another-beautiful-token-here'
+    secret nil
+    mastodon_client { build(:mastodon_client, domain: masto_domain) unless masto_domain.nil? }
+
+    after(:create) do |auth|
+      auth.mastodon_client.save!
+    end
   end
 end

--- a/test/factories/mastodon_client.rb
+++ b/test/factories/mastodon_client.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :mastodon_client do
+    domain Faker::Internet.domain_name
+    client_id 'The-client-id'
+    client_secret 'A-very-secret-key'
+  end
+end

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -22,7 +22,7 @@ FactoryGirl.define do
       masto_domain Faker::Internet.domain_name
     end
     after(:build) do |user, evaluator|
-      user.authorizations << build(:authorization_mastodon, user: user, uid: "#{evaluator.username}@#{evaluator.masto_domain}")
+      user.authorizations << build(:authorization_mastodon, user: user, masto_domain: evaluator.masto_domain, uid: "#{evaluator.username}@#{evaluator.masto_domain}")
       user.authorizations << build(:authorization_twitter, user: user)
     end
 

--- a/test/models/authorization_test.rb
+++ b/test/models/authorization_test.rb
@@ -1,7 +1,10 @@
 require 'test_helper'
 
 class AuthorizationTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'Mastodon domain' do
+    expected_domain = 'my_domain.com'
+    user = create(:user_with_mastodon_and_twitter, masto_domain: expected_domain)
+
+    assert_equal expected_domain, user.mastodon.send(:mastodon_domain)
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -141,6 +141,7 @@ class UserTest < ActiveSupport::TestCase
     expected_domain = 'my_domain.com'
 
     authorization = build(:authorization_mastodon, uid: "user@#{expected_domain}")
+    mastodon_client = create(:mastodon_client, domain: expected_domain).reload
     auth = mock()
     credentials = mock()
     auth.expects(:provider).at_least(1).returns(authorization.provider)
@@ -157,6 +158,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal authorization.uid, u.mastodon.uid
     assert_equal authorization.token, u.mastodon.token
     assert_equal authorization.secret, u.mastodon.secret
+    assert_equal mastodon_client.id, u.mastodon.mastodon_client_id
   end
 
   test 'Omniauth with no previous user, not allowing new users' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -203,4 +203,29 @@ class UserTest < ActiveSupport::TestCase
       user.save!
     end
   end
+  test 'User changes domain and toot counter is not reset' do
+    user = create(:user_with_mastodon_and_twitter, last_toot: 20010010)
+
+    authorization = build(:authorization_mastodon, uid: user.mastodon.uid, token: 'super-crazy-token')
+    auth = mock()
+    credentials = mock()
+    auth.expects(:provider).at_least(1).returns(authorization.provider)
+    auth.expects(:uid).at_least(1).returns(authorization.uid)
+    auth.expects(:credentials).at_least(1).returns(credentials)
+    credentials.expects(:token).returns(authorization.token)
+    credentials.expects(:secret).returns(authorization.secret)
+
+    mastodon_id = 123
+    expected_mastodon_status_id = 2
+    mastodon_client = mock()
+    user.expects(:mastodon_client).returns(mastodon_client)
+    user.expects(:mastodon_id).returns(mastodon_id)
+    mastodon_status = mock()
+    mastodon_client.expects(:statuses).with(mastodon_id, {limit: 1}).returns([mastodon_status])
+    mastodon_status.expects(:id).returns(expected_mastodon_status_id)
+
+    u = User.from_omniauth(auth, user)
+    assert_not_equal 20010010, u.last_toot
+    assert_equal expected_mastodon_status_id, u.last_toot
+  end
 end


### PR DESCRIPTION
Currently, there's no connection between the authorization and mastodon client. This creates this connection so that it's easier to connect status id and domain.
This should also fix #10.