### PR TITLE
Allow node versions newer than 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "webpack-dev-server": "^2.7.1"
   },
   "engines": {
-    "node": "6.x"
+    "node": ">=6.x"
   }
 }


### PR DESCRIPTION
Node 6.x is no longer maintained or supported, so version 8 LTS or newer should really be in use. This updates the engine requirement to allow versions newer than 6.x.