### PR TITLE
Removing potentially blocking SQL queries

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,6 +1,5 @@
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
@@ -17,9 +16,6 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 --
 -- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
 --
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
 
 SET search_path = public, pg_catalog;
 


### PR DESCRIPTION
On my setup (Ubuntu 16,04, as Mastodon install guide recommends it), some initial queries were blocking.

After some research, it appears the easiest solution was to remove them, as they're not really useful to create the database.