### PR TITLE
Adding ability to limit allowed Mastodon Accounts to a single domain

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,4 +1,6 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  skip_before_action :verify_authenticity_token, :only => [:failure]
+
   def all
     user = User.from_omniauth(request.env['omniauth.auth'], current_user)
 
@@ -13,6 +15,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   alias mastodon all
 
   def failure
-    redirect_to root_path
+    redirect_to root_path, flash: {error: failure_message}
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,3 +1,5 @@
+require 'mastodon_limited'
+
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
@@ -252,7 +254,7 @@ Devise.setup do |config|
   # up on your models and hooks.
   config.omniauth :twitter, ENV['TWITTER_CLIENT_ID'], ENV['TWITTER_CLIENT_SECRET']
 
-  config.omniauth :mastodon, scope: 'read write', credentials: lambda { |domain, callback_url|
+  config.omniauth :mastodon_limited, scope: 'read write', credentials: lambda { |domain, callback_url|
     client = MastodonClient.where(domain: domain).first_or_initialize(domain: domain)
 
     return [client.client_id, client.client_secret] unless client.new_record?

--- a/lib/mastodon_limited.rb
+++ b/lib/mastodon_limited.rb
@@ -1,0 +1,17 @@
+require 'mastodon'
+
+module OmniAuth
+  module Strategies
+    class MastodonLimited < OmniAuth::Strategies::Mastodon
+      def start_oauth
+        username, domain = identifier.split('@')
+        allowed_domain = ENV['ALLOWED_DOMAIN']
+        if not allowed_domain or allowed_domain == domain
+          super
+        else
+          fail!(:forbidden_domain, CallbackError.new("forbidden_domain", "Sorry, only %s Mastodon Accounts are allowed." % allowed_domain))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
For people (like me) who wants to self-host their mastodon-twitter-poster instance, it may be useful to limit allowed Mastodon Accounts to a single instance.

This commit allows to do this, on an optional basis.

Please note this is my really first Ruby development, so I apologize if it does not fit Ruby or Rails best practices, feel free to make any improvment.