### PR TITLE
fix statsd binary path to include custom node_modules paths

### DIFF
--- a/Procfile.worker
+++ b/Procfile.worker
@@ -1,2 +1,2 @@
 worker: bundle exec ruby script/daemon.rb run check_for_statuses.rb
-statsd: node node_modules/statsd/stats.js statsd-config.js
+statsd: node node_modules/.bin/statsd statsd-config.js


### PR DESCRIPTION
Both `npm` as well as `yarn` provide options of having custom directories for the `node_modules` directory.

I'll talk about `yarn` since it is recommended in the project.
`yarn` does this in a straight-forward way with the [`--modules-folder`](https://yarnpkg.com/en/docs/cli/install#toc-yarn-install-modules-folder) command-line argument. What it essentially does is that it installs all of the packages in the directory specified as the argument to the `--modules-folder` option, but at the same time, creates a hidden `.bin` directory in the `node_modules` directory in the root of the repository with symlinks to the actual binaries in the `--modules-folder`.

This is a clean and efficient way of handling custom paths for the `node_modules` directory, even though the directory is still present in the root of the repository.

However, if one did use a custom directory to install their node packages in this repository, it would break the initialization process since the path to the `statsd` module has been hard-coded into the `Procfile.worker` file. This change essentially uses the binary symlink to the actual module from the `node_modules/.bin` directory so that it works for everyone - be it one who simply installed the packages or one who specified a custom directory to install the packages.