### PR TITLE
check-in example systemd service files for ease of use

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ WantedBy=multi-user.target
 And put it on `/etc/systemd/system/crossposter-sidekiq.service`
 (note that RAILS_MAX_THREADS and the number of sidekiq threads should be the same)
 
+These example files are provided in the `config/systemd-services` directory. You may copy these files (with necessary modifications, if applicable) to `/etc/systemd/system/` to run the system in the background.
+
 ## Tests
 
 Run `RAILS_ENV=test bundle exec rake db:setup` to create the test database (a postgres running locally is needed), and after that run the tests with `bundle exec rake test` (or `COVERAGE=1 bundle exec rake test` if coverage information is desired)

--- a/config/systemd-services/crossposter-sidekiq.service.example
+++ b/config/systemd-services/crossposter-sidekiq.service.example
@@ -1,0 +1,16 @@
+[Unit]
+Description=mastodon-twitter-crossposter-sidekiq
+After=network.target
+
+[Service]
+Type=simple
+User=crossposter
+WorkingDirectory=/home/crossposter/live
+Environment="RAILS_ENV=production"
+Environment="RAILS_MAX_THREADS=5"
+ExecStart=/bin/bash -lc "bundle exec sidekiq -c 5 -q default"
+TimeoutSec=15
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/config/systemd-services/crossposter.service.example
+++ b/config/systemd-services/crossposter.service.example
@@ -1,0 +1,14 @@
+[Unit]
+Description=mastodon-twitter-crossposter
+After=network.target
+
+[Service]
+Type=simple
+User=crossposter
+WorkingDirectory=/home/crossposter/live
+ExecStart=/bin/bash -lc "bundle exec foreman start -e .env.production"
+TimeoutSec=15
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
It would be hard for users to copy-paste the service files from the README which could also introduce typographical error; so, having an example file would help in modifying the files and applying it to the system faster.

`systemd` is the thing now, so, it wouldn't do harm in checking in the service files to the repository. I put the example files in the `config` directory since that's what I think they are - service configuration files.