### PR TITLE
Add emojis to show the link to the original tweet in quote or RT

### DIFF
--- a/lib/twitter_user_processor.rb
+++ b/lib/twitter_user_processor.rb
@@ -137,7 +137,7 @@ class TwitterUserProcessor
     elsif user.retweet_post_as_old_rt? || user.retweet_post_as_old_rt_with_link?
       retweet = tweet.retweeted_status
       text, cw = convert_twitter_text(tweet.full_text.dup, tweet.urls + retweet.urls, (tweet.media + retweet.media).uniq)
-      text << "\n#{retweet.url}" if user.retweet_post_as_old_rt_with_link?
+      text << "\n🐦🔗: #{retweet.url}" if user.retweet_post_as_old_rt_with_link?
       save_status = true
       toot(text, @medias, tweet.possibly_sensitive? || user.twitter_content_warning.present? || cw.present?, save_status, cw || user.twitter_content_warning)
     end
@@ -158,13 +158,13 @@ class TwitterUserProcessor
       quote = tweet.quoted_status
       full_text = "#{tweet.full_text.gsub(" #{tweet.urls.first.url}", '')}\nRT @#{quote.user.screen_name} #{quote.full_text}"
       text, cw = convert_twitter_text(full_text, tweet.urls + quote.urls, (tweet.media + quote.media).uniq)
-      text << "\n#{quote.url}" if user.quote_post_as_old_rt_with_link?
+      text << "\n🐦🔗: #{quote.url}" if user.quote_post_as_old_rt_with_link?
       if text.length <= 500
         save_status = true
         toot(text, @medias, tweet.possibly_sensitive? || user.twitter_content_warning.present? || cw.present?, save_status, cw || user.twitter_content_warning)
       else
         text, cw = convert_twitter_text("RT @#{quote.user.screen_name} #{quote.full_text}", quote.urls, quote.media)
-        text << "\n#{quote.url}" if user.quote_post_as_old_rt_with_link?
+        text << "\n🐦🔗: #{quote.url}" if user.quote_post_as_old_rt_with_link?
         save_status = false
         @idempotency_key = "#{user.mastodon.uid.split('@')[0]}-#{quote.id}"
         quote_id = toot(text, @medias, quote.possibly_sensitive? || user.twitter_content_warning.present? || cw.present?, save_status, cw || user.twitter_content_warning)

--- a/test/lib/twitter_user_processor_test.rb
+++ b/test/lib/twitter_user_processor_test.rb
@@ -339,7 +339,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     stub_request(:get, 'https://api.twitter.com/1.1/statuses/show/926388565587779584.json?tweet_mode=extended').to_return(web_fixture('twitter_quote.json'))
 
     t = user.twitter_client.status(926388565587779584, tweet_mode: 'extended')
-    text = "What about a quote?\nRT @renatolonddev@twitter.com Hello, world!\nhttps://twitter.com/renatolonddev/status/895751593924210690"
+    text = "What about a quote?\nRT @renatolonddev@twitter.com Hello, world!\n🐦🔗: https://twitter.com/renatolonddev/status/895751593924210690"
 
     twitter_user_processor = TwitterUserProcessor.new(t, user)
     twitter_user_processor.expects(:toot).with(text, [], false, true, nil).times(1).returns(nil)
@@ -403,7 +403,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     medias = [273, 273, 273, 273]
 
     sensitive = false
-    text = "RT @renatolonddev@twitter.com Another attempt, this time a very large tweet, with a lot of words and I'll only include the image at the end.\nThis way, we should go beyond the standard limit and somehow it will not show the link.\nAt least, that's what I'm hoping it's the issue. RTs of long tweets with media.\nhttps://twitter.com/renatolonddev/status/936747599071207425"
+    text = "RT @renatolonddev@twitter.com Another attempt, this time a very large tweet, with a lot of words and I'll only include the image at the end.\nThis way, we should go beyond the standard limit and somehow it will not show the link.\nAt least, that's what I'm hoping it's the issue. RTs of long tweets with media.\n🐦🔗: https://twitter.com/renatolonddev/status/936747599071207425"
 
     masto_status = mock()
     quote_masto_id = 919819281111
@@ -447,7 +447,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     medias = [273, 273, 273, 273]
 
     sensitive = true
-    text = "RT @renatolonddev@twitter.com Another attempt, this time a very large tweet, with a lot of words and I'll only include the image at the end.\nThis way, we should go beyond the standard limit and somehow it will not show the link.\nAt least, that's what I'm hoping it's the issue. RTs of long tweets with media.\nhttps://twitter.com/renatolonddev/status/936747599071207425"
+    text = "RT @renatolonddev@twitter.com Another attempt, this time a very large tweet, with a lot of words and I'll only include the image at the end.\nThis way, we should go beyond the standard limit and somehow it will not show the link.\nAt least, that's what I'm hoping it's the issue. RTs of long tweets with media.\n🐦🔗: https://twitter.com/renatolonddev/status/936747599071207425"
 
     masto_status = mock()
     quote_masto_id = 919819281111
@@ -540,7 +540,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     stub_request(:get, 'https://api.twitter.com/1.1/statuses/show/904738384861700096.json?tweet_mode=extended').to_return(web_fixture('twitter_retweet.json'))
 
     t = user.twitter_client.status(904738384861700096, tweet_mode: 'extended')
-    text = "RT @renatolonddev@twitter.com: test\nhttps://twitter.com/renatolonddev/status/896020223169581056"
+    text = "RT @renatolonddev@twitter.com: test\n🐦🔗: https://twitter.com/renatolonddev/status/896020223169581056"
 
     twitter_user_processor = TwitterUserProcessor.new(t, user)
     twitter_user_processor.expects(:toot).with(text, [], false, true, nil).times(1).returns(nil)


### PR DESCRIPTION
When the the "with link" option is on, the original link for the quote
or rt is shown. Add an emoji to make it more evident.