### PR TITLE
Add worker to check for token status and stop crossposting if needed

### DIFF
--- a/app/workers/process_user_worker.rb
+++ b/app/workers/process_user_worker.rb
@@ -15,5 +15,7 @@ class ProcessUserWorker
     self.class.stats.time("mastodon.processing_time") { MastodonUserProcessor.process_user(u) } if u.posting_from_mastodon
     u.locked = false
     u.save
+  rescue Twitter::Error::Unauthorized, Mastodon::Error::Unauthorized
+    UnauthorizedUserWorker.perform_async(id)
   end
 end

--- a/app/workers/unauthorized_user_worker.rb
+++ b/app/workers/unauthorized_user_worker.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class UnauthorizedUserWorker
+  include Sidekiq::Worker
+
+  REVOKED_MESSAGES = ["O token de acesso foi revogado", "The access token was revoked"]
+
+  def perform(id)
+    @user = User.find(id)
+    check_twitter_credentials
+    check_mastodon_credentials
+
+    @user.locked = false
+    @user.save
+  rescue ActiveRecord::RecordNotFound
+    Rails.logger.debug { "User not found, ignoring" }
+  end
+
+  private
+    def check_twitter_credentials
+      if @user.twitter
+        begin
+          @user.twitter_client.verify_credentials
+        rescue Twitter::Error::Unauthorized => ex
+          if ex.code == 89
+            @user.twitter.destroy
+            stop_crossposting
+          end
+        end
+      end
+    end
+
+    def check_mastodon_credentials
+      if @user.mastodon
+        begin
+          @user.mastodon_client.verify_credentials
+        rescue Mastodon::Error::Unauthorized => ex
+          # XXX look into this. There should be a code or machine-readable error field
+          if REVOKED_MESSAGES.include? ex.message
+            @user.mastodon.destroy
+            stop_crossposting
+          end
+        end
+      end
+    end
+
+    def stop_crossposting
+      @user.posting_from_twitter = @user.posting_from_mastodon = false
+      @user.save
+    end
+end

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -22,6 +22,29 @@ FactoryBot.define do
     twitter_quote_visibility { "unlisted" }
   end
 
+  factory :user_with_twitter, parent: :user do |user|
+    after(:build) do |user, evaluator|
+      user.authorizations << build(:authorization_twitter, user: user)
+    end
+
+    after(:create) do |user|
+      user.authorizations.each { |authorization| authorization.save! }
+    end
+  end
+
+  factory :user_with_mastodon, parent: :user do |user|
+    transient do
+      masto_domain { Faker::Internet.domain_name }
+    end
+    after(:build) do |user, evaluator|
+      user.authorizations << build(:authorization_mastodon, user: user, masto_domain: evaluator.masto_domain, uid: "#{evaluator.username}@#{evaluator.masto_domain}")
+    end
+
+    after(:create) do |user|
+      user.authorizations.each { |authorization| authorization.save! }
+    end
+  end
+
   factory :user_with_mastodon_and_twitter, parent: :user do |user|
     transient do
       masto_domain { Faker::Internet.domain_name }

--- a/test/workers/unauthorized_user_worker_test.rb
+++ b/test/workers/unauthorized_user_worker_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "minitest/mock"
+
+class UnauthorizedUserWorkerTest < ActiveSupport::TestCase
+  test "Unauthorized twitter error without the correct code is ignored" do
+    user = create(:user_with_twitter, posting_from_twitter: true)
+    twitter_client = mock()
+    user.expects(:twitter_client).returns(twitter_client)
+    User.expects(:find).with(user.id).returns(user)
+    twitter_client.expects(:verify_credentials).raises(Twitter::Error::Unauthorized)
+
+    Sidekiq::Testing.inline! do
+      UnauthorizedUserWorker.perform_async(user.id)
+    end
+
+    assert_equal 1, user.authorizations.count
+    assert user.posting_from_twitter
+  end
+
+  test "Unauthorized twitter error with the correct code remove twitter and stops crossposting" do
+    user = create(:user_with_twitter, posting_from_twitter: true)
+    twitter_client = mock()
+    user.expects(:twitter_client).returns(twitter_client)
+    User.expects(:find).with(user.id).returns(user)
+    err = Twitter::Error::Unauthorized.new("blah", {}, 89)
+    twitter_client.expects(:verify_credentials).raises(err)
+
+    Sidekiq::Testing.inline! do
+      UnauthorizedUserWorker.perform_async(user.id)
+    end
+
+    assert_equal 0, user.authorizations.count
+    assert_not user.posting_from_twitter
+  end
+
+  test "Unauthorized mastodon error without the correct message is ignored" do
+    user = create(:user_with_mastodon, posting_from_mastodon: true)
+    mastodon_client = mock()
+    user.expects(:mastodon_client).returns(mastodon_client)
+    User.expects(:find).with(user.id).returns(user)
+    mastodon_client.expects(:verify_credentials).raises(Mastodon::Error::Unauthorized)
+
+    Sidekiq::Testing.inline! do
+      UnauthorizedUserWorker.perform_async(user.id)
+    end
+
+    assert_equal 1, user.authorizations.count
+    assert user.posting_from_mastodon
+  end
+
+  test "Unauthorized mastodon error with the correct message removes mastodon and stops crossposting" do
+    user = create(:user_with_mastodon, posting_from_mastodon: true)
+    mastodon_client = mock()
+    user.expects(:mastodon_client).returns(mastodon_client)
+    User.expects(:find).with(user.id).returns(user)
+    err = Mastodon::Error::Unauthorized.new("The access token was revoked")
+    mastodon_client.expects(:verify_credentials).raises(err)
+
+    Sidekiq::Testing.inline! do
+      UnauthorizedUserWorker.perform_async(user.id)
+    end
+
+    assert_equal 0, user.authorizations.count
+    assert_not user.posting_from_mastodon
+  end
+
+  test "User not found, ignore" do
+    user_id = 999
+    User.expects(:find).with(user_id).raises(ActiveRecord::RecordNotFound)
+
+    Sidekiq::Testing.inline! do
+      UnauthorizedUserWorker.perform_async(user_id)
+    end
+  end
+end


### PR DESCRIPTION
Adds a new worker that's triggered when an unauthorized error is raised. The worker checks the status of the tokens and removes them if they are invalid.