### PR TITLE
Allow user to choose content warning options when cross-posting from Mastodon to Twitter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ env:
   global:
     - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct; else git log -1 --skip 1 --pretty=format:%ct; fi)
     - COVERAGE=1
-    - PGPORT=5433
 language: ruby
 cache:
     bundler: true
@@ -13,10 +12,8 @@ rvm:
   - 2.6.5
 bundler_args: --without production
 addons:
-    postgresql: "13"
+    postgresql: "9.6"
     apt_packages:
-      - postgresql-13
-      - postgresql-client-13
       - libmagic-dev # used for ruby-filemagic
       - libidn11-dev # used for twitter text
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ env:
   global:
     - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct; else git log -1 --skip 1 --pretty=format:%ct; fi)
     - COVERAGE=1
+    - PGPORT=5433
 language: ruby
 cache:
     bundler: true
@@ -12,8 +13,10 @@ rvm:
   - 2.6.5
 bundler_args: --without production
 addons:
-    postgresql: "9.6"
+    postgresql: "13"
     apt_packages:
+      - postgresql-13
+      - postgresql-client-13
       - libmagic-dev # used for ruby-filemagic
       - libidn11-dev # used for twitter text
 before_script:

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,11 +42,19 @@ class User < ApplicationRecord
     unlisted: "MASTO_UNLISTED",
     private: "MASTO_PRIVATE"
   }.freeze
+
+  cw_options = {
+    cw_and_content: "CW_AND_CONTENT",
+    cw_only: "CW_ONLY",
+    content_only: "CONTENT_ONLY"
+  }.freeze
+
   enum twitter_original_visibility: masto_visibility, _prefix: true
   enum twitter_retweet_visibility: masto_visibility, _prefix: true
   enum twitter_quote_visibility: masto_visibility, _prefix: true
   enum masto_block_or_allow_list: block_or_allow, _prefix: true
   enum twitter_block_or_allow_list: block_or_allow, _prefix: true
+  enum masto_cw_options: cw_options, _prefix: true
 
   before_validation :strip_whitespace
   before_validation :remove_empty_words_from_wordlist

--- a/app/views/users/advanced_mastodon.html.erb
+++ b/app/views/users/advanced_mastodon.html.erb
@@ -58,6 +58,19 @@
   </div>
 
   <div class="field">
+    <label class="label"><%= t :masto_cw_options %></label>
+    <div class="control">
+      <% User.masto_cw_options.keys.each do |option| %>
+      <%= f.label :masto_cw_options, value: option, class: 'radio' do %>
+      <%= f.radio_button :masto_cw_options, option %>
+      <%= t option.to_sym %>
+      <% end %>
+      <% end %>
+    </div>
+    <p class="help"><%= t :masto_cw_options_explanation %></p>
+  </div>
+
+  <div class="field">
     <label class="label"><%= t '.masto_block_or_allow_list' %></label>
     <div class="control">
       <%= f.label :masto_block_or_allow_list, value: '', class: 'radio' do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,10 +6,13 @@ en:
   boost_options: 'Boost options:'
   change_this_on_options: You can change these settings by going to %{options}.
   connections: Connections
+  content_only: Content only
   crossposter_explanation: This service allows you to connect a Mastodon account and
     a Twitter account and enable cross-posting between them. You can choose some options,
     such as if you want to post boosts, unlisted toots or replies.
   crossposting_overview: Options overview
+  cw_and_content: Both CW and content
+  cw_only: CW only
   default_visibility: Use Mastodon default visibility
   disconnect: Disconnect
   errors:
@@ -51,6 +54,9 @@ en:
   manage_your_accounts: Manage your connected accounts
   masto_boost_do_not_post: Do not post boosts on Twitter
   masto_boost_post_as_link: 'Post boosts on Twitter as links (Boosted: https://mastodon.social/@renatolond/15082784)'
+  masto_cw_options: 'Content warning (CW) options:'
+  masto_cw_options_explanation: When cross-posting a toot that has a content warning,
+    this setting will determine which parts of the toot should be cross-posted.
   masto_login:
     identifier: Identifier
     invalid_identifier: Invalid identifier. You need to use the format user@instance,

--- a/db/migrate/20210109000000_add_masto_cw_to_twitter_options.rb
+++ b/db/migrate/20210109000000_add_masto_cw_to_twitter_options.rb
@@ -3,6 +3,6 @@ class AddMastoCwToTwitterOptions < ActiveRecord::Migration[5.1]
     execute <<-SQL
       CREATE TYPE masto_cw_options AS ENUM ('CW_AND_CONTENT', 'CONTENT_ONLY', 'CW_ONLY');
     SQL
-    add_column :users, :masto_cw_options, :masto_cw_options
+    add_column :users, :masto_cw_options, :masto_cw_options, null: false, default: "CW_ONLY"
   end
 end

--- a/db/migrate/20210109000000_add_masto_cw_to_twitter_options.rb
+++ b/db/migrate/20210109000000_add_masto_cw_to_twitter_options.rb
@@ -1,0 +1,8 @@
+class AddMastoCwToTwitterOptions < ActiveRecord::Migration[5.1]
+  def change
+    execute <<-SQL
+      CREATE TYPE masto_cw_options AS ENUM ('CW_AND_CONTENT', 'CONTENT_ONLY', 'CW_ONLY');
+    SQL
+    add_column :users, :masto_cw_options, :masto_cw_options
+  end
+end

--- a/db/migrate/20210109000000_add_masto_cw_to_twitter_options.rb
+++ b/db/migrate/20210109000000_add_masto_cw_to_twitter_options.rb
@@ -1,7 +1,7 @@
 class AddMastoCwToTwitterOptions < ActiveRecord::Migration[5.1]
   def change
     execute <<-SQL
-      CREATE TYPE masto_cw_options AS ENUM ('CW_AND_CONTENT', 'CONTENT_ONLY', 'CW_ONLY');
+      CREATE TYPE masto_cw_options AS ENUM ('CW_AND_CONTENT', 'CW_ONLY', 'CONTENT_ONLY');
     SQL
     add_column :users, :masto_cw_options, :masto_cw_options, null: false, default: "CW_ONLY"
   end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,22 +5,9 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
-
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
 
 --
 -- Name: block_or_allow; Type: TYPE; Schema: public; Owner: -
@@ -39,6 +26,17 @@ CREATE TYPE public.block_or_allow AS ENUM (
 CREATE TYPE public.boost_options AS ENUM (
     'MASTO_BOOST_DO_NOT_POST',
     'MASTO_BOOST_POST_AS_LINK'
+);
+
+
+--
+-- Name: masto_cw_options; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.masto_cw_options AS ENUM (
+    'CW_AND_CONTENT',
+    'CONTENT_ONLY',
+    'CW_ONLY'
 );
 
 
@@ -108,7 +106,7 @@ CREATE TYPE public.twitter_reply_options AS ENUM (
 
 SET default_tablespace = '';
 
-SET default_with_oids = false;
+SET default_table_access_method = heap;
 
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
@@ -266,7 +264,8 @@ CREATE TABLE public.users (
     twitter_block_or_allow_list public.block_or_allow,
     masto_word_list character varying[] DEFAULT '{}'::character varying[],
     masto_block_or_allow_list public.block_or_allow,
-    admin boolean DEFAULT false NOT NULL
+    admin boolean DEFAULT false NOT NULL,
+    masto_cw_options public.masto_cw_options
 );
 
 
@@ -460,6 +459,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190131082017'),
 ('20190202145018'),
 ('20190226132236'),
-('20200328180158');
+('20200328180158'),
+('20210109000000');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -48,8 +48,8 @@ CREATE TYPE public.boost_options AS ENUM (
 
 CREATE TYPE public.masto_cw_options AS ENUM (
     'CW_AND_CONTENT',
-    'CONTENT_ONLY',
-    'CW_ONLY'
+    'CW_ONLY',
+    'CONTENT_ONLY'
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -278,7 +278,7 @@ CREATE TABLE public.users (
     masto_word_list character varying[] DEFAULT '{}'::character varying[],
     masto_block_or_allow_list public.block_or_allow,
     admin boolean DEFAULT false NOT NULL,
-    masto_cw_options public.masto_cw_options
+    masto_cw_options public.masto_cw_options DEFAULT 'CW_ONLY'::public.masto_cw_options NOT NULL
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,9 +5,22 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
-SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
 
 --
 -- Name: block_or_allow; Type: TYPE; Schema: public; Owner: -
@@ -106,7 +119,7 @@ CREATE TYPE public.twitter_reply_options AS ENUM (
 
 SET default_tablespace = '';
 
-SET default_table_access_method = heap;
+SET default_with_oids = false;
 
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -

--- a/lib/mastodon_user_processor.rb
+++ b/lib/mastodon_user_processor.rb
@@ -282,7 +282,23 @@ class MastodonUserProcessor
 
   def toot_content_to_post
     if toot.sensitive? && toot.spoiler_text.present?
-      "CW: #{toot.spoiler_text} … #{toot.url}"
+      if user.masto_cw_options == "cw_and_content"
+        if should_add_image_count?
+          "CW: #{toot.spoiler_text}\n\n#{toot.text_content}… #{toot.media_attachments.count} 🖼️"
+        else
+          "CW: #{toot.spoiler_text}\n\n#{toot.text_content}"
+        end
+      elsif user.masto_cw_options == "cw_only"
+        "CW: #{toot.spoiler_text} … #{toot.url}"
+      elsif user.masto_cw_options == "content_only"
+        if should_add_image_count?
+          "#{toot.text_content}… #{toot.media_attachments.count} 🖼️"
+        else
+          toot.text_content
+        end
+      else
+        raise "invalid masto_cw_options"
+      end
     elsif should_add_image_count?
       "#{toot.text_content}… #{toot.media_attachments.count} 🖼️"
     else

--- a/lib/mastodon_user_processor.rb
+++ b/lib/mastodon_user_processor.rb
@@ -281,29 +281,31 @@ class MastodonUserProcessor
   end
 
   def toot_content_to_post
+    tweet = toot.text_content
+    tweet_includes_content = true
+
     if toot.sensitive? && toot.spoiler_text.present?
       if user.masto_cw_options == "cw_and_content"
-        if should_add_image_count?
-          "CW: #{toot.spoiler_text}\n\n#{toot.text_content}… #{toot.media_attachments.count} 🖼️"
-        else
-          "CW: #{toot.spoiler_text}\n\n#{toot.text_content}"
-        end
+        tweet = "CW: #{toot.spoiler_text}\n\n#{toot.text_content}"
       elsif user.masto_cw_options == "cw_only"
-        "CW: #{toot.spoiler_text} … #{toot.url}"
+        tweet = "CW: #{toot.spoiler_text}"
+        tweet_includes_content = false
       elsif user.masto_cw_options == "content_only"
-        if should_add_image_count?
-          "#{toot.text_content}… #{toot.media_attachments.count} 🖼️"
-        else
-          toot.text_content
-        end
+        tweet = toot.text_content
       else
         raise "invalid masto_cw_options"
       end
-    elsif should_add_image_count?
-      "#{toot.text_content}… #{toot.media_attachments.count} 🖼️"
-    else
-      toot.text_content
     end
+
+    unless tweet_includes_content
+      @force_toot_url = true
+    end
+
+    if tweet_includes_content && should_add_image_count?
+      tweet = "#{tweet}… #{toot.media_attachments.count} 🖼️"
+    end
+
+    tweet
   end
 
   def should_post

--- a/lib/mastodon_user_processor.rb
+++ b/lib/mastodon_user_processor.rb
@@ -297,9 +297,7 @@ class MastodonUserProcessor
       end
     end
 
-    unless tweet_includes_content
-      @force_toot_url = true
-    end
+    @force_toot_url = true unless tweet_includes_content
 
     if tweet_includes_content && should_add_image_count?
       tweet = "#{tweet}… #{toot.media_attachments.count} 🖼️"

--- a/test/lib/mastodon_user_processor_test.rb
+++ b/test/lib/mastodon_user_processor_test.rb
@@ -168,6 +168,48 @@ class MastodonUserProcessorTest < ActiveSupport::TestCase
     mastodon_user_processor.process_normal_toot
   end
 
+  test "process normal toot with content warning, post content only" do
+    user = create(:user_with_mastodon_and_twitter, masto_domain: "mastodon.xyz", masto_cw_options: "content_only")
+    text = "Another test of CW"
+
+    stub_request(:get, "https://mastodon.xyz/api/v1/statuses/7009409").to_return(web_fixture("status7009409.json"))
+    t = user.mastodon_client.status(7_009_409)
+
+    mastodon_user_processor = MastodonUserProcessor.new(t, user)
+    mastodon_user_processor.expects(:should_post).returns(true)
+    mastodon_user_processor.expects(:tweet).with(text, {}).times(1).returns(nil)
+
+    mastodon_user_processor.process_normal_toot
+  end
+
+  test "process normal toot with content warning, post cw and content" do
+    user = create(:user_with_mastodon_and_twitter, masto_domain: "mastodon.xyz", masto_cw_options: "cw_and_content")
+    text = "CW: Test 2\n\nAnother test of CW"
+
+    stub_request(:get, "https://mastodon.xyz/api/v1/statuses/7009409").to_return(web_fixture("status7009409.json"))
+    t = user.mastodon_client.status(7_009_409)
+
+    mastodon_user_processor = MastodonUserProcessor.new(t, user)
+    mastodon_user_processor.expects(:should_post).returns(true)
+    mastodon_user_processor.expects(:tweet).with(text, {}).times(1).returns(nil)
+
+    mastodon_user_processor.process_normal_toot
+  end
+
+  test "process normal toot with content warning, post with link" do
+    user = create(:user_with_mastodon_and_twitter, masto_domain: "mastodon.xyz")
+    text = "CW: Test 2… https://mastodon.xyz/@renatolonddev/7009409"
+
+    stub_request(:get, "https://mastodon.xyz/api/v1/statuses/7009409").to_return(web_fixture("status7009409.json"))
+    t = user.mastodon_client.status(7_009_409)
+
+    mastodon_user_processor = MastodonUserProcessor.new(t, user)
+    mastodon_user_processor.expects(:should_post).returns(true)
+    mastodon_user_processor.expects(:tweet).with(text, {}).times(1).returns(nil)
+
+    mastodon_user_processor.process_normal_toot
+  end
+
   test "process normal toot - toot marked as sensitive, without cw, with no images" do
     user = create(:user_with_mastodon_and_twitter, masto_domain: "masto.donte.com.br")
     first_text = "Oh, this is a good word: chocolate!"


### PR DESCRIPTION
As a user crossposting from Mastodon to Twitter, it should be possible to configure how to handle toots with content warnings. Some users may want to display just the content warning, some may want to display just the content, some may want both. The default should be to display just the content warning.

I am not a Ruby on Rails developer, and I probably did this wrong. I know that I'm missing tests, translations, etc, but I wanted to submit what I've managed to put together so far. Hopefully I can get some assistance in getting this feature finished and merged!