### PR TITLE
docker: specify python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apk -U upgrade \
     build-base \
     postgresql-dev \
     postgresql-client \
-    python \
+    python3 \
     file-dev \
     binutils \
     libxml2-dev \


### PR DESCRIPTION
otherwise i get this on a fresh `docker-compose build`:
```
Step 13/22 : RUN apk -U upgrade  && apk add -t build-dependencies     build-base     postgresql-dev     postgresql-client     python     file-dev     binutils     libxml2-dev     libidn-dev  && apk add     ca-certificates     git  && update-ca-certificates  && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn  && ln -s /opt/yarn/bin/yarnpkg /usr/local/bin/yarnpkg  && mkdir -p /opt  && cd /crossposter  && rm -rf /tmp/* /var/cache/apk/*
 ---> Running in a57255923ee3
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/community/x86_64/APKINDEX.tar.gz
Upgrading critical system libraries and apk-tools:
(1/1) Upgrading apk-tools (2.12.0-r4 -> 2.12.1-r0)
Executing busybox-1.32.1-r0.trigger
Continuing the upgrade transaction with new apk-tools:
(1/3) Upgrading busybox (1.32.1-r0 -> 1.32.1-r2)
Executing busybox-1.32.1-r2.post-upgrade
(2/3) Upgrading ssl_client (1.32.1-r0 -> 1.32.1-r2)
(3/3) Upgrading musl-utils (1.2.2_pre7-r0 -> 1.2.2-r0)
Executing busybox-1.32.1-r2.trigger
OK: 20 MiB in 36 packages
ERROR: unable to select packages:
  python (no such package):
    required by: build-dependencies-20210128.050825[python]
ERROR: Service 'web' failed to build : The command '/bin/sh -c apk -U upgrade  && apk add -t build-dependencies     build-base     postgresql-dev     postgresql-client     python     file-dev     binutils     libxml2-dev     libidn-dev  && apk add     ca-certificates     git  && update-ca-certificates  && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn  && ln -s /opt/yarn/bin/yarnpkg /usr/local/bin/yarnpkg  && mkdir -p /opt  && cd /crossposter  && rm -rf /tmp/* /var/cache/apk/*' returned a non-zero code: 2
```