### PR TITLE
Update dependency in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apk -U upgrade \
     build-base \
     postgresql-dev \
     postgresql-client \
-    python \
+    python3 \
     file-dev \
     binutils \
     libxml2-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apk -U upgrade \
     binutils \
     libxml2-dev \
     libidn-dev \
+    shared-mime-info \
  && apk add \
     ca-certificates \
     git \


### PR DESCRIPTION
`python`: gives the error `ERROR: unable to select package`. It should be `python3` now.