### PR TITLE
Bump node version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine as node
+FROM node:18-alpine as node
 FROM ruby:3.1.0-alpine
 
 LABEL maintainer="https://github.com/renatolond/mastodon-twitter-poster" \


### PR DESCRIPTION
Node's version needs to be above 14 to install some dependencies (and as stated in the 2022-10-18's CHANGELOG).  
I've set the docker tag to the current LTS, 18.