### PR TITLE
Remove option to post quotes and RTs publicly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+[2022-11-11] - [IMPORTANT] Removes the option for retweets and quote-retweets to be posted publicly.
+
 [2022-11-04] - Add Stoplight, a gem that acts as a circuitbreaker. This will give a cooldown to servers that might be offline.
 
 [2022-10-18] - Update gems and node dependencies. `bundle install` and `yarn install --pure-lockfile` needed after upgrade.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,6 +43,11 @@ class User < ApplicationRecord
     private: "MASTO_PRIVATE"
   }.freeze
 
+  masto_limited_visibility = {
+    unlisted: "MASTO_UNLISTED",
+    private: "MASTO_PRIVATE"
+  }.freeze
+
   cw_options = {
     cw_and_content: "CW_AND_CONTENT",
     cw_only: "CW_ONLY",
@@ -50,8 +55,8 @@ class User < ApplicationRecord
   }.freeze
 
   enum twitter_original_visibility: masto_visibility, _prefix: true
-  enum twitter_retweet_visibility: masto_visibility, _prefix: true
-  enum twitter_quote_visibility: masto_visibility, _prefix: true
+  enum twitter_retweet_visibility: masto_limited_visibility, _prefix: true
+  enum twitter_quote_visibility: masto_limited_visibility, _prefix: true
   enum masto_block_or_allow_list: block_or_allow, _prefix: true
   enum twitter_block_or_allow_list: block_or_allow, _prefix: true
   enum masto_cw_options: cw_options, _prefix: true

--- a/app/views/users/advanced_twitter.html.erb
+++ b/app/views/users/advanced_twitter.html.erb
@@ -34,7 +34,7 @@
     <%= f.label :twitter_retweet_visibility, t(:twitter_retweet_visibility), class: 'label' %>
     <div class="control">
       <div class="select">
-        <%= f.select :twitter_retweet_visibility, translated_masto_privacy_for_select(User, :twitter_retweet_visibilities), { include_blank: t('default_visibility') } %>
+        <%= f.select :twitter_retweet_visibility, translated_masto_privacy_for_select(User, :twitter_retweet_visibilities) %>
       </div>
     </div>
   </div>
@@ -55,7 +55,7 @@
     <%= f.label :twitter_quote_visibility, t(:twitter_quote_visibility), class: 'label' %>
     <div class="control">
       <div class="select">
-        <%= f.select :twitter_quote_visibility, translated_masto_privacy_for_select(User, :twitter_quote_visibilities), { include_blank: t('default_visibility') } %>
+        <%= f.select :twitter_quote_visibility, translated_masto_privacy_for_select(User, :twitter_quote_visibilities) %>
       </div>
     </div>
   </div>

--- a/db/migrate/20221111102341_limit_visibility_for_quotes_and_rts.rb
+++ b/db/migrate/20221111102341_limit_visibility_for_quotes_and_rts.rb
@@ -1,0 +1,24 @@
+class LimitVisibilityForQuotesAndRts < ActiveRecord::Migration[7.0]
+  def change
+    execute <<-SQL
+      CREATE TYPE masto_limited_visibility AS ENUM ('MASTO_UNLISTED', 'MASTO_PRIVATE');
+      UPDATE users set twitter_retweet_visibility = 'MASTO_UNLISTED' WHERE twitter_retweet_visibility is NULL or twitter_retweet_visibility = 'MASTO_PUBLIC';
+      UPDATE users set twitter_quote_visibility = 'MASTO_UNLISTED' WHERE twitter_quote_visibility is NULL or twitter_quote_visibility = 'MASTO_PUBLIC';
+
+      ALTER TABLE users
+      ALTER COLUMN twitter_retweet_visibility SET DEFAULT NULL,
+      ALTER COLUMN twitter_quote_visibility SET DEFAULT NULL;
+
+      ALTER TABLE users
+      ALTER COLUMN twitter_retweet_visibility SET NOT NULL,
+      ALTER COLUMN twitter_retweet_visibility SET DEFAULT 'MASTO_UNLISTED'::masto_limited_visibility,
+      ALTER COLUMN twitter_retweet_visibility TYPE masto_limited_visibility USING twitter_retweet_visibility::varchar::masto_limited_visibility;
+
+      ALTER TABLE users
+      ALTER COLUMN twitter_quote_visibility SET NOT NULL,
+      ALTER COLUMN twitter_quote_visibility SET DEFAULT 'MASTO_UNLISTED'::masto_limited_visibility,
+      ALTER COLUMN twitter_quote_visibility TYPE masto_limited_visibility USING twitter_quote_visibility::varchar::masto_limited_visibility;
+    SQL
+    change_column :users, :twitter_quote_visibility, :masto_limited_visibility, null: false
+  end
+end

--- a/db/migrate/20221111102341_limit_visibility_for_quotes_and_rts.rb
+++ b/db/migrate/20221111102341_limit_visibility_for_quotes_and_rts.rb
@@ -1,5 +1,5 @@
 class LimitVisibilityForQuotesAndRts < ActiveRecord::Migration[7.0]
-  def change
+  def up
     execute <<-SQL
       CREATE TYPE masto_limited_visibility AS ENUM ('MASTO_UNLISTED', 'MASTO_PRIVATE');
       UPDATE users set twitter_retweet_visibility = 'MASTO_UNLISTED' WHERE twitter_retweet_visibility is NULL or twitter_retweet_visibility = 'MASTO_PUBLIC';
@@ -19,6 +19,27 @@ class LimitVisibilityForQuotesAndRts < ActiveRecord::Migration[7.0]
       ALTER COLUMN twitter_quote_visibility SET DEFAULT 'MASTO_UNLISTED'::masto_limited_visibility,
       ALTER COLUMN twitter_quote_visibility TYPE masto_limited_visibility USING twitter_quote_visibility::varchar::masto_limited_visibility;
     SQL
-    change_column :users, :twitter_quote_visibility, :masto_limited_visibility, null: false
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE users
+      ALTER COLUMN twitter_quote_visibility DROP NOT NULL,
+      ALTER COLUMN twitter_quote_visibility SET DEFAULT NULL;
+
+      ALTER TABLE users
+      ALTER COLUMN twitter_quote_visibility SET DEFAULT 'MASTO_UNLISTED'::masto_visibility,
+      ALTER COLUMN twitter_quote_visibility TYPE masto_visibility USING twitter_quote_visibility::varchar::masto_visibility;
+
+      ALTER TABLE users
+      ALTER COLUMN twitter_retweet_visibility DROP NOT NULL,
+      ALTER COLUMN twitter_retweet_visibility SET DEFAULT NULL;
+
+      ALTER TABLE users
+      ALTER COLUMN twitter_retweet_visibility SET DEFAULT 'MASTO_UNLISTED'::masto_visibility,
+      ALTER COLUMN twitter_retweet_visibility TYPE masto_visibility USING twitter_retweet_visibility::varchar::masto_visibility;
+
+      DROP TYPE masto_limited_visibility;
+    SQL
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -54,6 +54,16 @@ CREATE TYPE public.masto_cw_options AS ENUM (
 
 
 --
+-- Name: masto_limited_visibility; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.masto_limited_visibility AS ENUM (
+    'MASTO_UNLISTED',
+    'MASTO_PRIVATE'
+);
+
+
+--
 -- Name: masto_mention_options; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -271,8 +281,8 @@ CREATE TABLE public.users (
     twitter_content_warning character varying,
     locked boolean DEFAULT false NOT NULL,
     twitter_original_visibility public.masto_visibility,
-    twitter_retweet_visibility public.masto_visibility DEFAULT 'MASTO_UNLISTED'::public.masto_visibility,
-    twitter_quote_visibility public.masto_visibility DEFAULT 'MASTO_UNLISTED'::public.masto_visibility,
+    twitter_retweet_visibility public.masto_limited_visibility DEFAULT 'MASTO_UNLISTED'::public.masto_limited_visibility NOT NULL,
+    twitter_quote_visibility public.masto_limited_visibility DEFAULT 'MASTO_UNLISTED'::public.masto_limited_visibility NOT NULL,
     twitter_word_list character varying[] DEFAULT '{}'::character varying[],
     twitter_block_or_allow_list public.block_or_allow,
     masto_word_list character varying[] DEFAULT '{}'::character varying[],
@@ -473,6 +483,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190202145018'),
 ('20190226132236'),
 ('20200328180158'),
-('20210109000000');
+('20210109000000'),
+('20221111102341');
 
 

--- a/test/lib/twitter_user_processor_test.rb
+++ b/test/lib/twitter_user_processor_test.rb
@@ -428,7 +428,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     masto_domain = "comidas.social"
     authorization_masto = build(:authorization_mastodon, uid: "#{masto_user}@#{masto_domain}", masto_domain: masto_domain)
     authorization_twitter = build(:authorization_twitter)
-    user = create(:user, authorizations: [authorization_masto, authorization_twitter], quote_options: User.quote_options["quote_post_as_old_rt_with_link"], twitter_quote_visibility: nil)
+    user = create(:user, authorizations: [authorization_masto, authorization_twitter], quote_options: User.quote_options["quote_post_as_old_rt_with_link"], twitter_quote_visibility: User.twitter_retweet_visibilities["unlisted"])
 
     stub_request(:get, "https://api.twitter.com/1.1/statuses/show/1042806820212011008.json?tweet_mode=extended&include_ext_alt_text=true").to_return(web_fixture("twitter_quote_bigger_than_500_chars_with_cw.json"))
     stub_request(:get, "http://pbs.twimg.com/media/DkFZEoVXgAQs0tJ.jpg")
@@ -448,7 +448,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     masto_status = mock()
     quote_masto_id = 919819281111
     masto_status.expects(:id).returns(quote_masto_id).once
-    user.mastodon_client.expects(:create_status).with(text, media_ids: medias, sensitive: true, spoiler_text: spoiler_text, headers: { "Idempotency-Key" => "#{masto_user}-#{t.quoted_status.id}" }).returns(masto_status)
+    user.mastodon_client.expects(:create_status).with(text, media_ids: medias, visibility: "unlisted", sensitive: true, spoiler_text: spoiler_text, headers: { "Idempotency-Key" => "#{masto_user}-#{t.quoted_status.id}" }).returns(masto_status)
 
     text = "Esse é um tweet bem grande que vai ser quebrado em dois quando for pego pelo crosspost. A ideia é que não vai pegar o CN no RT.\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad mi"
     medias = []
@@ -456,7 +456,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     masto_status = mock()
     masto_id = 919819281112
     masto_status.expects(:id).returns(masto_id).twice
-    user.mastodon_client.expects(:create_status).with(text, media_ids: medias, sensitive: true, spoiler_text: spoiler_text, in_reply_to_id: quote_masto_id, headers: { "Idempotency-Key" => "#{masto_user}-#{t.id}" }).returns(masto_status)
+    user.mastodon_client.expects(:create_status).with(text, media_ids: medias, visibility: "unlisted", sensitive: true, spoiler_text: spoiler_text, in_reply_to_id: quote_masto_id, headers: { "Idempotency-Key" => "#{masto_user}-#{t.id}" }).returns(masto_status)
 
     twitter_user_processor = TwitterUserProcessor.new(t, user)
     twitter_user_processor.process_quote
@@ -467,7 +467,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     masto_domain = "comidas.social"
     authorization_masto = build(:authorization_mastodon, uid: "#{masto_user}@#{masto_domain}", masto_domain: masto_domain)
     authorization_twitter = build(:authorization_twitter)
-    user = create(:user, authorizations: [authorization_masto, authorization_twitter], quote_options: User.quote_options["quote_post_as_old_rt_with_link"], twitter_quote_visibility: nil)
+    user = create(:user, authorizations: [authorization_masto, authorization_twitter], quote_options: User.quote_options["quote_post_as_old_rt_with_link"], twitter_quote_visibility: User.twitter_retweet_visibilities["unlisted"])
 
     stub_request(:get, "https://api.twitter.com/1.1/statuses/show/936933954241945606.json?tweet_mode=extended&include_ext_alt_text=true").to_return(web_fixture("twitter_quote_bigger_than_500_chars.json"))
     stub_request(:get, "http://pbs.twimg.com/media/DP_-xzZXkAcQAkY.png")
@@ -492,7 +492,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     masto_status = mock()
     quote_masto_id = 919819281111
     masto_status.expects(:id).returns(quote_masto_id).once
-    user.mastodon_client.expects(:create_status).with(text, media_ids: medias, headers: { "Idempotency-Key" => "#{masto_user}-#{t.quoted_status.id}" }).returns(masto_status)
+    user.mastodon_client.expects(:create_status).with(text, media_ids: medias, visibility: "unlisted", headers: { "Idempotency-Key" => "#{masto_user}-#{t.quoted_status.id}" }).returns(masto_status)
 
     text = "That's the kind of status that gives us problems. It's very annoying a status so big that it will go over the 500 characters of mastodon. But it can happen if you join two big statuses together. Well, in that case, it should not be trying to crosspost it all at once."
     medias = []
@@ -500,7 +500,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     masto_status = mock()
     masto_id = 919819281112
     masto_status.expects(:id).returns(masto_id).twice
-    user.mastodon_client.expects(:create_status).with(text, media_ids: medias, in_reply_to_id: quote_masto_id, headers: { "Idempotency-Key" => "#{masto_user}-#{t.id}" }).returns(masto_status)
+    user.mastodon_client.expects(:create_status).with(text, media_ids: medias, visibility: "unlisted", in_reply_to_id: quote_masto_id, headers: { "Idempotency-Key" => "#{masto_user}-#{t.id}" }).returns(masto_status)
 
     twitter_user_processor = TwitterUserProcessor.new(t, user)
     twitter_user_processor.process_quote
@@ -511,7 +511,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     masto_domain = "comidas.social"
     authorization_masto = build(:authorization_mastodon, uid: "#{masto_user}@#{masto_domain}", masto_domain: masto_domain)
     authorization_twitter = build(:authorization_twitter)
-    user = create(:user, authorizations: [authorization_masto, authorization_twitter], quote_options: User.quote_options["quote_post_as_old_rt_with_link"], twitter_content_warning: "Twitter stuff", twitter_quote_visibility: nil)
+    user = create(:user, authorizations: [authorization_masto, authorization_twitter], quote_options: User.quote_options["quote_post_as_old_rt_with_link"], twitter_content_warning: "Twitter stuff", twitter_quote_visibility: User.twitter_retweet_visibilities["unlisted"])
 
     stub_request(:get, "https://api.twitter.com/1.1/statuses/show/936933954241945606.json?tweet_mode=extended&include_ext_alt_text=true").to_return(web_fixture("twitter_quote_bigger_than_500_chars.json"))
     stub_request(:get, "http://pbs.twimg.com/media/DP_-xzZXkAcQAkY.png")
@@ -536,7 +536,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     masto_status = mock()
     quote_masto_id = 919819281111
     masto_status.expects(:id).returns(quote_masto_id).once
-    user.mastodon_client.expects(:create_status).with(text, sensitive: sensitive, media_ids: medias, spoiler_text: "Twitter stuff", headers: { "Idempotency-Key" => "#{masto_user}-#{t.quoted_status.id}" }).returns(masto_status)
+    user.mastodon_client.expects(:create_status).with(text, sensitive: sensitive, visibility: "unlisted", media_ids: medias, spoiler_text: "Twitter stuff", headers: { "Idempotency-Key" => "#{masto_user}-#{t.quoted_status.id}" }).returns(masto_status)
 
     text = "That's the kind of status that gives us problems. It's very annoying a status so big that it will go over the 500 characters of mastodon. But it can happen if you join two big statuses together. Well, in that case, it should not be trying to crosspost it all at once."
     medias = []
@@ -544,7 +544,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     masto_status = mock()
     masto_id = 919819281112
     masto_status.expects(:id).returns(masto_id).twice
-    user.mastodon_client.expects(:create_status).with(text, sensitive: sensitive, media_ids: medias, in_reply_to_id: quote_masto_id, spoiler_text: "Twitter stuff", headers: { "Idempotency-Key" => "#{masto_user}-#{t.id}" }).returns(masto_status)
+    user.mastodon_client.expects(:create_status).with(text, sensitive: sensitive, visibility: "unlisted", media_ids: medias, in_reply_to_id: quote_masto_id, spoiler_text: "Twitter stuff", headers: { "Idempotency-Key" => "#{masto_user}-#{t.id}" }).returns(masto_status)
 
     twitter_user_processor = TwitterUserProcessor.new(t, user)
     twitter_user_processor.process_quote
@@ -555,7 +555,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     spoiler_text = "Twitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuffTwitter stuff"
     authorization_masto = build(:authorization_mastodon, uid: "#{masto_user}@#{masto_domain}", masto_domain: masto_domain)
     authorization_twitter = build(:authorization_twitter)
-    user = create(:user, authorizations: [authorization_masto, authorization_twitter], quote_options: User.quote_options["quote_post_as_old_rt_with_link"], twitter_content_warning: spoiler_text, twitter_quote_visibility: nil)
+    user = create(:user, authorizations: [authorization_masto, authorization_twitter], quote_options: User.quote_options["quote_post_as_old_rt_with_link"], twitter_content_warning: spoiler_text, twitter_quote_visibility: User.twitter_retweet_visibilities["unlisted"])
 
     stub_request(:get, "https://api.twitter.com/1.1/statuses/show/936734115738669057.json?tweet_mode=extended&include_ext_alt_text=true").to_return(web_fixture("twitter_quote_of_quote.json"))
 
@@ -568,7 +568,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     masto_status = mock()
     quote_masto_id = 919819281111
     masto_status.expects(:id).returns(quote_masto_id).once
-    user.mastodon_client.expects(:create_status).with(text, sensitive: sensitive, media_ids: medias, spoiler_text: spoiler_text, headers: { "Idempotency-Key" => "#{masto_user}-#{t.quoted_status.id}" }).returns(masto_status)
+    user.mastodon_client.expects(:create_status).with(text, sensitive: sensitive, visibility: "unlisted", media_ids: medias, spoiler_text: spoiler_text, headers: { "Idempotency-Key" => "#{masto_user}-#{t.quoted_status.id}" }).returns(masto_status)
 
     text = "Maybe I have to quote this one, then?"
     medias = []
@@ -576,7 +576,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     masto_status = mock()
     masto_id = 919819281112
     masto_status.expects(:id).returns(masto_id).twice
-    user.mastodon_client.expects(:create_status).with(text, sensitive: sensitive, media_ids: medias, in_reply_to_id: quote_masto_id, spoiler_text: spoiler_text, headers: { "Idempotency-Key" => "#{masto_user}-#{t.id}" }).returns(masto_status)
+    user.mastodon_client.expects(:create_status).with(text, sensitive: sensitive, visibility: "unlisted", media_ids: medias, in_reply_to_id: quote_masto_id, spoiler_text: spoiler_text, headers: { "Idempotency-Key" => "#{masto_user}-#{t.id}" }).returns(masto_status)
 
     twitter_user_processor = TwitterUserProcessor.new(t, user)
     twitter_user_processor.process_quote
@@ -586,7 +586,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     masto_domain = "comidas.social"
     authorization_masto = build(:authorization_mastodon, uid: "#{masto_user}@#{masto_domain}", masto_domain: masto_domain)
     authorization_twitter = build(:authorization_twitter)
-    user = create(:user, authorizations: [authorization_masto, authorization_twitter], quote_options: User.quote_options["quote_post_as_old_rt"], twitter_quote_visibility: nil)
+    user = create(:user, authorizations: [authorization_masto, authorization_twitter], quote_options: User.quote_options["quote_post_as_old_rt"], twitter_quote_visibility: User.twitter_retweet_visibilities["unlisted"])
 
     stub_request(:get, "https://api.twitter.com/1.1/statuses/show/936933954241945606.json?tweet_mode=extended&include_ext_alt_text=true").to_return(web_fixture("twitter_quote_bigger_than_500_chars.json"))
     stub_request(:get, "http://pbs.twimg.com/media/DP_-xzZXkAcQAkY.png")
@@ -611,7 +611,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     masto_status = mock()
     quote_masto_id = 919819281111
     masto_status.expects(:id).returns(quote_masto_id).once
-    user.mastodon_client.expects(:create_status).with(text, media_ids: medias, headers: { "Idempotency-Key" => "#{masto_user}-#{t.quoted_status.id}" }).returns(masto_status)
+    user.mastodon_client.expects(:create_status).with(text, media_ids: medias, visibility: "unlisted", headers: { "Idempotency-Key" => "#{masto_user}-#{t.quoted_status.id}" }).returns(masto_status)
 
     text = "That's the kind of status that gives us problems. It's very annoying a status so big that it will go over the 500 characters of mastodon. But it can happen if you join two big statuses together. Well, in that case, it should not be trying to crosspost it all at once."
     medias = []
@@ -619,7 +619,7 @@ class TwitterUserProcessorTest < ActiveSupport::TestCase
     masto_status = mock()
     masto_id = 919819281112
     masto_status.expects(:id).returns(masto_id).twice
-    user.mastodon_client.expects(:create_status).with(text, media_ids: medias, in_reply_to_id: quote_masto_id, headers: { "Idempotency-Key" => "#{masto_user}-#{t.id}" }).returns(masto_status)
+    user.mastodon_client.expects(:create_status).with(text, media_ids: medias, visibility: "unlisted", in_reply_to_id: quote_masto_id, headers: { "Idempotency-Key" => "#{masto_user}-#{t.id}" }).returns(masto_status)
 
     twitter_user_processor = TwitterUserProcessor.new(t, user)
     twitter_user_processor.process_quote


### PR DESCRIPTION
Over the years my plan was to work on #124 to allow admins to disable public RTs and quotes and reduce spam on their servers.
I never had the time and the latest user waves have increased this issue to the point that in some servers most of the local instance posts are crossposts.

I decided to remove this option from the crossposter to reduce the overall friction over the crossposter. This should reduce the overall posts that one sees in their timeline unless they follow the person posting.
This is a big change and reduces the options for crossposter users.