### PR TITLE
Bump Redis to version 7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   redis:
     restart: always
-    image: redis:5.0-alpine
+    image: redis:7-alpine
     networks:
       - internal_network
     healthcheck:


### PR DESCRIPTION
This is a drop-in replacement for better performance, also Redis 5 is EOL.